### PR TITLE
Write a test for an helper function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,19 +8,16 @@ version = "0.1.3"
 
 [workspace]
 exclude = ["sandbox"]
-members = [
-  "racoon_macros",
-  "racoon_mailer",
-]
+members = ["racoon_macros", "racoon_mailer"]
 
 [dependencies]
 anyhow = "1.0.68"
-async-graphql = {version = "4.0.6"}
+async-graphql = { version = "4.0.6" }
 async-session = "3.0.0"
 async-trait = "0.1.57"
-axum = {version = "0.5.16", features = ["headers", "json", "ws"]}
+axum = { version = "0.5.16", features = ["headers", "json", "ws"] }
 bcrypt = "0.13.0"
-chrono = {version = "0.4.22", features = ["serde"]}
+chrono = { version = "0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 futures = "0.3.23"
 headers = "0.3.8"
@@ -30,17 +27,29 @@ lettre = "0.10.1"
 oauth2 = "4.3.0"
 once_cell = "1.15.0"
 otp-rs = "0.1.1"
-racoon_macros = {path = "./racoon_macros"}
-racoon_mailer = {path = "./racoon_mailer"}
-reqwest = {version = "0.11", default-features = false, features = ["rustls-tls", "json"]}
-serde = {version = "1.0.144", features = ["derive"]}
+racoon_macros = { path = "./racoon_macros" }
+racoon_mailer = { path = "./racoon_mailer" }
+reqwest = { version = "0.11", default-features = false, features = [
+  "rustls-tls",
+  "json",
+] }
+serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
-sqlx = {version = "0.6.2", features = ["runtime-tokio-rustls", "postgres", "any", "uuid", "migrate", "chrono", "time"]}
+sqlx = { version = "0.6.2", features = [
+  "runtime-tokio-rustls",
+  "postgres",
+  "any",
+  "uuid",
+  "migrate",
+  "chrono",
+  "time",
+] }
 thiserror = "1.0.29"
-tokio = {version = "1.20.1", features = ["full"]}
-tower-http = {version = "0.3.4", features = ["cors", "fs", "trace"]}
+time = "0.3.20"
+tokio = { version = "1.20.1", features = ["full"] }
+tower-http = { version = "0.3.4", features = ["cors", "fs", "trace"] }
 tracing = "0.1.36"
-tracing-subscriber = {version = "0.3", features = ["env-filter"]}
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.3.1"
-uuid = {version = "1.1.2", features = ["serde", "v4"]}
-validator = {version = "0.16.0", features = ["derive"]}
+uuid = { version = "1.1.2", features = ["serde", "v4"] }
+validator = { version = "0.16.0", features = ["derive"] }

--- a/src/controllers/auth_controllers.rs
+++ b/src/controllers/auth_controllers.rs
@@ -12,9 +12,10 @@ use jsonwebtoken::{encode, Algorithm, Header};
 use serde_json::{json, Value};
 use sqlx::PgPool;
 use std::env;
+use time;
 
-const ACCESS_TOKEN_VALIDITY: u64 = 10; // the bearer token validity set to 10 minutes
-const REFRESH_TOKEN_VALIDITY: u64 = 25; // 25 minutes for refresh token validity
+const ACCESS_TOKEN_VALIDITY: time::Duration = time::Duration::minutes(10); // the bearer token validity set to 10 minutes
+const REFRESH_TOKEN_VALIDITY: time::Duration = time::Duration::minutes(25); // 25 minutes for refresh token validity
 
 /// create new user account
 pub async fn sign_up(

--- a/src/controllers/auth_controllers.rs
+++ b/src/controllers/auth_controllers.rs
@@ -3,7 +3,7 @@ use crate::models::emails::EmailPayload;
 use crate::models::users::{AccountStatus, ResetUserPassword, UserInformation, UserModel};
 use crate::utils::api_response::{ApiErrorResponse, ApiSuccessResponse, ValidatedRequest};
 use crate::utils::jwt::JWT_SECRET;
-use crate::utils::jwt::{set_jtw_exp, JwtClaims, JwtPayload};
+use crate::utils::jwt::{set_jwt_exp, JwtClaims, JwtPayload};
 use crate::utils::message_queue::MessageQueue;
 use crate::utils::otp_handler::Otp;
 use crate::utils::sql_query_builder::{Create, Find, FindByPk};
@@ -52,7 +52,7 @@ pub async fn sign_up(
         id: user_id.to_string(),
         email: email.as_ref().unwrap().to_string(),
         fullname: fullname.as_ref().unwrap().to_string(),
-        exp: set_jtw_exp(ACCESS_TOKEN_VALIDITY), //set expirations
+        exp: set_jwt_exp(ACCESS_TOKEN_VALIDITY), //set expirations
     };
 
     // build the JWT Token and create a new token
@@ -166,7 +166,7 @@ pub async fn request_new_otp(
         id: user_id.to_string(),
         email: email.as_ref().unwrap().to_string(),
         fullname: fullname.as_ref().unwrap().to_string(),
-        exp: set_jtw_exp(ACCESS_TOKEN_VALIDITY), //set expirations
+        exp: set_jwt_exp(ACCESS_TOKEN_VALIDITY), //set expirations
     };
 
     // build the JWT Token and create a new token
@@ -234,7 +234,7 @@ pub async fn request_account_verification(
         id: user_id.to_string(),
         email: email.as_ref().unwrap().to_string(),
         fullname: fullname.as_ref().unwrap().to_string(),
-        exp: set_jtw_exp(ACCESS_TOKEN_VALIDITY), //set expirations
+        exp: set_jwt_exp(ACCESS_TOKEN_VALIDITY), //set expirations
     };
 
     // build the JWT Token and create a new token
@@ -327,7 +327,7 @@ pub async fn login(
             .as_ref()
             .unwrap_or(&"default".to_string())
             .to_string(),
-        exp: set_jtw_exp(ACCESS_TOKEN_VALIDITY), //set expirations
+        exp: set_jwt_exp(ACCESS_TOKEN_VALIDITY), //set expirations
     };
     //fetch the JWT secret
     /*   let jwt_secret = crate::shared::jwt_schema::jwt_secret(); */
@@ -421,7 +421,7 @@ pub async fn request_password_reset(
             .as_ref()
             .unwrap_or(&"default".to_string())
             .to_string(),
-        exp: set_jtw_exp(ACCESS_TOKEN_VALIDITY), //set expirations
+        exp: set_jwt_exp(ACCESS_TOKEN_VALIDITY), //set expirations
     };
     let token = jwt_payload.generate_token().unwrap();
     let response: ApiSuccessResponse<JwtPayload> = ApiSuccessResponse::<JwtPayload> {
@@ -554,7 +554,7 @@ pub async fn get_refresh_token(
                 id: id.to_string(),
                 email: email.as_ref().unwrap().to_string(),
                 fullname: fullname.as_ref().unwrap().to_string(),
-                exp: set_jtw_exp(REFRESH_TOKEN_VALIDITY), //set expirations
+                exp: set_jwt_exp(REFRESH_TOKEN_VALIDITY), //set expirations
             };
             //fetch the JWT secret
             /*   let jwt_secret = crate::shared::jwt_schema::jwt_secret(); */

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -51,33 +51,6 @@ impl JwtClaims {
         encode(&jwt_header, &self, &JWT_SECRET.encoding).ok()
     }
 }
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use dotenv::dotenv;
-
-    #[test]
-    fn test_jwt_encoder() {
-        dotenv().ok();
-
-        // set token to expire in 10 mines
-        let expiration_time = set_jwt_exp(10);
-        //generate sample token
-        let sample_claim: JwtClaims = JwtClaims {
-            id: String::from("16260b1d-1554-5b6f-a221-56ff4b34199c"),
-            email: String::from("cout@lahpev.mg"),
-            fullname: String::from("Jesse Rodney"),
-            exp: expiration_time,
-        };
-        let token = sample_claim.generate_token();
-        // let token: String = token.unwrap();
-
-        //see if the length of the token is greater than 10
-        // println!("{}", &token);
-        // assert!(Some('e') == token.chars().next());
-        assert!(token.is_some());
-    }
-}
 
 #[async_trait]
 impl<S> FromRequest<S> for JwtClaims
@@ -169,4 +142,31 @@ pub fn set_jwt_exp(exp: u64) -> u64 {
 
     //return the result as seconds
     hours_from_now.as_secs()
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dotenv::dotenv;
+
+    #[test]
+    fn test_jwt_encoder() {
+        dotenv().ok();
+
+        // set token to expire in 10 mines
+        let expiration_time = set_jwt_exp(10);
+        //generate sample token
+        let sample_claim: JwtClaims = JwtClaims {
+            id: String::from("16260b1d-1554-5b6f-a221-56ff4b34199c"),
+            email: String::from("cout@lahpev.mg"),
+            fullname: String::from("Jesse Rodney"),
+            exp: expiration_time,
+        };
+        let token = sample_claim.generate_token();
+        // let token: String = token.unwrap();
+
+        //see if the length of the token is greater than 10
+        // println!("{}", &token);
+        // assert!(Some('e') == token.chars().next());
+        assert!(token.is_some());
+    }
 }

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -61,7 +61,7 @@ mod tests {
         dotenv().ok();
 
         // set token to expire in 10 mines
-        let expiration_time = set_jtw_exp(10);
+        let expiration_time = set_jwt_exp(10);
         //generate sample token
         let sample_claim: JwtClaims = JwtClaims {
             id: String::from("16260b1d-1554-5b6f-a221-56ff4b34199c"),
@@ -154,7 +154,7 @@ pub struct JwtPayload {
 
 /// set the expiration of token
 /// accept the exp as the minutes from now ehn the token will be  invalidated
-pub fn set_jtw_exp(exp: u64) -> u64 {
+pub fn set_jwt_exp(exp: u64) -> u64 {
     // the current time
     let now = SystemTime::now();
     // unix epoch elapsed time

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -54,9 +54,12 @@ impl JwtClaims {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dotenv::dotenv;
 
     #[test]
     fn test_jwt_encoder() {
+        dotenv().ok();
+
         // set token to expire in 10 mines
         let expiration_time = set_jtw_exp(10);
         //generate sample token

--- a/src/utils/otp_handler.rs
+++ b/src/utils/otp_handler.rs
@@ -150,8 +150,12 @@ impl Otp {
 #[cfg(test)]
 mod test {
     use super::Otp;
+    use dotenv::dotenv;
+
     #[test]
     fn otp_is_generated() {
+        dotenv().ok();
+
         let otp = Otp::new();
         let otp: u32 = otp.token.parse().unwrap();
         assert!(otp > 0)


### PR DESCRIPTION
Fix #138

- I had to load the environment variables with `dotenv` for some unit tests in order for them to pass
- I fixed a typo in the function name (was `set_jtw_exp`)
- I moved the tests module as requested
- I added tests to validate the `set_jwt_exp` function as requested. Note that I had to partially modify how the function was implemented in order to mock SystemTime
- I changed the parameter type `exp` (and its usage) to be more explicit. Instead of `u64` conventionally expressed in minutes, we now use a `Duration` struct